### PR TITLE
feat: add example .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Environment Configuration Example
+# Copy this file to .env and fill in your actual values
+
+# Email Configuration
+# The email address used for receiving support tickets
+EMAIL_ADDRESS=your-email@example.com
+
+# Email password or app-specific password for authentication
+EMAIL_PASSWORD=your-email-password
+
+# IMAP server address for reading incoming emails
+IMAP_SERVER=imap.example.com
+
+# GitHub Configuration
+# Personal Access Token with repo scope for creating PRs and pushing changes
+GITHUB_PAT=ghp_your-github-personal-access-token
+
+# Claude Configuration
+# Path to the Claude CLI executable
+CLAUDE_PATH=/path/to/claude


### PR DESCRIPTION
Closes #1

This PR adds a `.env.example` file with placeholder values and comments explaining each configuration field:
- EMAIL_ADDRESS - Email for receiving support tickets
- EMAIL_PASSWORD - Email authentication password
- IMAP_SERVER - IMAP server address
- GITHUB_PAT - GitHub Personal Access Token
- CLAUDE_PATH - Path to Claude CLI executable